### PR TITLE
Minor syntax fix

### DIFF
--- a/json-schema/1.x/structure.md
+++ b/json-schema/1.x/structure.md
@@ -247,7 +247,7 @@ in depth in the next chapters.
 | `[1, "a"]`{:.language-json} | *valid*{:.text-success.text-normal} |
 | `[-5.1, 10.8, 2]`{:.language-json} | *valid*{:.text-success.text-normal} |
 | `["a", "b", "c", "d", 4, 5]`{:.language-json} | *valid*{:.text-success.text-normal} |
-| `[1]` {:.language-json} | *invalid*{:.text-danger.text-normal} - must have at least 2 items |
+| `[1]`{:.language-json} | *invalid*{:.text-danger.text-normal} - must have at least 2 items |
 | `["a", {"x": 1}]`{:.language-json} | *invalid*{:.text-danger.text-normal} - contains an object |
 | `{"0": 1, "1": 2}`{:.language-json} | *invalid*{:.text-danger.text-normal} - not an array |
 {:.table}


### PR DESCRIPTION
Was going through the docs and saw a minor difference in the html... looking at the md the only difference is a space after the back tick.

![60D1624C-B833-405A-934B-7B1C644385F1](https://user-images.githubusercontent.com/2445415/106825792-e397ec00-6685-11eb-9bcf-4845a5865740.jpeg)
