### PR TITLE
Docs: Fix the order of params in the registerPrefix() example.

### DIFF
--- a/json-schema/2.x/php-loader.md
+++ b/json-schema/2.x/php-loader.md
@@ -95,7 +95,7 @@ Use this method to register a filesystem directory from where to load schema fil
 You must specify the id prefix.
 
 ```php
-$resolver->registerPreifx('/path/to/dir', 'http://example.com/');
+$resolver->registerPrefix('http://example.com/','/path/to/dir');
 ```
 
 In the above example we create a loader that maps 


### PR DESCRIPTION
The parameters in the example were in the wrong order, it had me scratching my head a little bit when I copy/pasted it. 😉