### PR TITLE
PHP VALIDATOR: Add space after `=` in assignment statement

### DIFF
--- a/json-schema/2.x/php-validator.md
+++ b/json-schema/2.x/php-validator.md
@@ -128,7 +128,7 @@ $data = "opis";
 // null
 $data = null;
 // boolean
-$data = true; $data =false;
+$data = true; $data = false;
 // array
 $data = [1, 2, 3];
 // object


### PR DESCRIPTION
This PR adds a space after the `=` symbol in an assignment statement that was missing in the `php-validator.md` file.