### PR TITLE
Added a performance notice for using uniqueItems on larger array datasets

### DIFF
--- a/json-schema/2.x/array.md
+++ b/json-schema/2.x/array.md
@@ -105,6 +105,9 @@ more than once in the array.
 The value of this keyword must be a boolean. If set to `false` the keyword
 validation will be ignored.
 
+Be aware of additional processing time needed when enabling `uniqueItems` for larger JSON arrays, especially JSON arrays of objects.
+{:.alert.alert-warning data-title="Performance"}
+
 {% capture schema %}
 ```json
 {


### PR DESCRIPTION
I ran into an issue where I had `uniqueItems` enabled and it was hurting performance when using larger data-sets.

Added a performance note to the documentation so anyone searching or using this feature is aware.